### PR TITLE
Remove manual lib linking and specify UDP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,8 @@ RUN mkdir $STEAMEXE && \
 ENV INSTALL_DIR $HW_HOME/serverfiles
 RUN /usr/local/steamcmd/steamcmd.sh +force_install_dir $INSTALL_DIR +login anonymous +app_update 405100 validate +quit
 
-# symlink steam client libs
+# symlink steamcmd deps
 RUN ln -s $INSTALL_DIR/steam_appid.txt $HW_HOME/steam_appid.txt
-RUN ln -s $STEAMEXE/linux32/steamclient.so $INSTALL_DIR/Hurtworld_Data/Plugins/x86/steamclient.so
-RUN ln -s $INSTALL_DIR/linux64/steamclient.so $INSTALL_DIR/Hurtworld_Data/Plugins/x86_64/steamclient.so
 
 # ensure $HW_HOME is owned by $HW_USER
 RUN chown -R $HW_USER:$HW_USER $HW_HOME
@@ -39,8 +37,8 @@ RUN chown -R $HW_USER:$HW_USER $HW_HOME
 # copy any custom stuff added to the server
 COPY rootfs /
 
-EXPOSE 12871
-EXPOSE 12881
+EXPOSE 12871/udp
+EXPOSE 12881/udp
 
 USER $HW_USER
 WORKDIR $HW_HOME

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-all:
+all: build runserver
+
+build:
 	docker build -t fishworks/hwserver .
 
 run:
@@ -8,4 +10,4 @@ shell:
 	docker run -it fishworks/hwserver bash
 
 runserver:
-	docker run -d -p 12871:12871 -p 12881:12881 fishworks/hwserver
+	docker run -d -p 12871:12871/udp -p 12881:12881/udp fishworks/hwserver

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project contains a Dockerfile for getting [a Hurtworld server](http://hurtw
 
 First, install [docker](https://www.docker.com/).
 
-	$ make
+	$ make build
 	$ make runserver
 	docker run -dP fishworks/hwserver
 	b0d7d753caeac465acaf55f790f85e973a1fce17bc19518df6c2538464f96a45


### PR DESCRIPTION
#### Remove manual symlinking of steamcmd libs

This workaround is no longer required.
#### Specify UDP Explicitly

Clients were unable to connect and the server would not show up in the list because Docker defaults to TCP only. This specifies UDP in both the Dockerfile's `EXPOSE` as well as in the provided run command in the `Makefile`

Also, made the `all` target `build` + `runserver` for convenience and explicitly labeled the `build` step.
